### PR TITLE
Fixed failing javadoc (Fixes #3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
 						<configuration>
 							<packageName>${project.groupId}.iib.generated.eclipse_project</packageName>
 							<clearOutputDir>false</clearOutputDir>
-							<includes>
-								<include>EclipseProject.xsd</include>
-							</includes>
+							<sources>
+								<source>src/main/xsd/EclipseProject.xsd</source>
+							</sources>
 						</configuration>
 					</execution>
 					<execution>
@@ -133,9 +133,9 @@
 						<configuration>
 							<packageName>${project.groupId}.iib.generated.maven_pom</packageName>
 							<clearOutputDir>false</clearOutputDir>
-							<includes>
-								<include>maven-v4_0_0.xsd</include>
-							</includes>
+							<sources>
+								<source>src/main/xsd/maven-v4_0_0.xsd</source>
+							</sources>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>jaxb2-maven-plugin</artifactId>
-				<version>1.6</version>
+				<version>2.5.0</version>
 				<executions>
 					<execution>
 						<id>eclipseProject</id>

--- a/src/main/java/ch/sbb/maven/plugins/iib/mojos/PackageBarMojo.java
+++ b/src/main/java/ch/sbb/maven/plugins/iib/mojos/PackageBarMojo.java
@@ -49,7 +49,7 @@ public class PackageBarMojo extends AbstractMojo {
     protected String excludeArtifactsPattern;
 
     /**
-     * Include artifacts pattern (or patterns, comma separated). By default, the default value used for mqsipackagebar, except .esql & .subflow, which as not compilable
+     * Include artifacts pattern (or patterns, comma separated). By default, the default value used for mqsipackagebar, except .esql &amp; .subflow, which as not compilable
      * 
      * @see <a href="http://www-01.ibm.com/support/knowledgecenter/SSMKHH_9.0.0/com.ibm.etools.mft.doc/bc31720_.htm">IIB9 Documentation</a>
      */

--- a/src/main/java/ch/sbb/maven/plugins/iib/utils/ApplyBarOverride.java
+++ b/src/main/java/ch/sbb/maven/plugins/iib/utils/ApplyBarOverride.java
@@ -14,7 +14,7 @@ import com.ibm.broker.config.proxy.LogEntry;
 /**
  * Highly borrowed from
  * 
- * @see com.ibm.broker.config.util.ApplyBarOverride
+ * com.ibm.broker.config.util.ApplyBarOverride
  * 
  * @author u209936 (Jamie Townsend)
  * @since 2.1, 2015

--- a/src/main/java/ch/sbb/maven/plugins/iib/utils/ReadBar.java
+++ b/src/main/java/ch/sbb/maven/plugins/iib/utils/ReadBar.java
@@ -10,7 +10,7 @@ import com.ibm.broker.config.proxy.DeploymentDescriptor;
 /**
  * Highly borrowed from
  * 
- * @see com.ibm.broker.config.util.ReadBar
+ * com.ibm.broker.config.util.ReadBar
  * 
  * @author u209936 (Jamie Townsend)
  * @since 2.1, 2015


### PR DESCRIPTION
- upgrade jaxb2-maven-plugin so that generated javadoc is no longer
wrong
- fixed comment with ampersand
- Removed javadoc links to classes that are not present in build